### PR TITLE
Update config to target es5 rather than es6.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,10 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "lib": ["es2015"],
     "module": "commonjs",
     "noImplicitAny": true,
     "outDir": "dist",
-    "target": "es2015"
+    "target": "es5"
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
This simplifies integrating into some setups targeting web. For example, with the es6 version, my webpack based setup threw an error in production mode when this was run through it's uglify.js step. Using 'babel-loader' on lens.ts fixed that issue.