### PR TITLE
mention to proxy object availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ objL.name // same as objL.k('name')
 arrL[0] // same as arrL.k(0)
 ```
 
+Note that proxy objects are not available in Internet Explorer as [caniuse describes](https://caniuse.com/#feat=proxy).
+
 ## Credits
 
 Property proxy couldn't have been implemented without


### PR DESCRIPTION
Because proxy objects are not available in Internet Explorer, it should be mentioned to in README.

cf. https://caniuse.com/#feat=proxy